### PR TITLE
:bar_chart: Add content column to CSV output (Issue #4)

### DIFF
--- a/model/http-client-app.h
+++ b/model/http-client-app.h
@@ -43,7 +43,7 @@ private:
   EventId m_event;
   Time m_interval{Seconds(1)};
   std::string m_resource{"/obj"};
-  std::unordered_map<uint32_t, Time> m_sendTimes;
+  std::unordered_map<uint32_t, std::pair<Time, std::string>> m_sendTimes;
   std::ofstream m_csv;
   std::string m_csvPath{"client_metrics.csv"};
   uint32_t m_nextId = 1;


### PR DESCRIPTION
## :memo: Summary

Fixes #4 - Adds per-content metrics to CSV output by including a `content` column showing which resource was requested.

## :bulb: Motivation

Enable analysis of cache performance per content item:
- Which content has highest/lowest hit rates
- Latency patterns per resource
- Validate Zipf distribution effectiveness
- Debug content-specific caching issues

## :wrench: Changes Made

### Data Structure
Changed `m_sendTimes` from storing just `Time` to storing `std::pair<Time, std::string>`:
```cpp
// Before
std::unordered_map<uint32_t, Time> m_sendTimes;

// After
std::unordered_map<uint32_t, std::pair<Time, std::string>> m_sendTimes;
```

### CSV Format
**Before:**
```csv
request_id,send_s,recv_s,latency_ms,cache_hit
1,0.8,0.815021,15,0
2,1.3,1.31502,15,0
```

**After:**
```csv
request_id,content,send_s,recv_s,latency_ms,cache_hit
1,/file-4,0.8,0.815021,15,0
2,/file-2,1.3,1.31502,15,0
3,/file-1,1.8,1.81502,15,0
```

### Files Modified
- `model/http-client-app.h` - Updated `m_sendTimes` type
- `model/http-client-app.cc` - Store and output content name

## :white_check_mark: Testing

:heavy_check_mark: **Build:** Successful compilation
```bash
./ns3 build
```

:heavy_check_mark: **CSV Output:** Verified content column appears correctly
```bash
./ns3 run http-cache-scenario -- --nReq=20 --numContent=5 --zipf=true --csv=test_content.csv
```

:heavy_check_mark: **Content Tracking:** All requests show correct resource names (/file-1, /file-2, etc.)

:heavy_check_mark: **Zipf Distribution:** Content popularity reflected in CSV (more /file-1 requests than /file-5)

## :chart_with_upwards_trend: Benefits

- **Per-content analysis:** Easy to filter and analyze by resource
- **Hit rate by content:** `SELECT content, AVG(cache_hit) FROM metrics GROUP BY content`
- **Latency by content:** Identify slow resources
- **Debugging:** Track specific content through the system

## :link: Related Issues

- Enables #6 (summary statistics per content)
- Complements #5 (numContent renaming)

## :mag: Example Analysis

With the new CSV format, you can easily analyze per-content performance:
```bash
# Count requests per content
cut -d',' -f2 test_content.csv | sort | uniq -c

# Average hit rate per content  
awk -F',' 'NR>1 {hits[$2]+=$6; total[$2]++} END {for(c in hits) print c, hits[c]/total[c]}' test_content.csv
```