### PR TITLE
:zap: Add configurable cache hit latency (Issue #7)

### DIFF
--- a/examples/http-cache-scenario.cc
+++ b/examples/http-cache-scenario.cc
@@ -13,7 +13,7 @@ int main(int argc, char** argv){
   Time::SetResolution(Time::NS);
   uint32_t nReq = 100; double interval=0.5; uint32_t cacheCap=4; double ttl=5.0;
   std::string resource = "/file-A"; std::string csv = "client_metrics.csv";
-  uint32_t numContent = 1; bool zipf = false; double zipfS = 1.0; uint32_t originDelay = 1;
+  uint32_t numContent = 1; bool zipf = false; double zipfS = 1.0; uint32_t originDelay = 1; uint32_t cacheDelay = 1;
   CommandLine cmd;
   cmd.AddValue("nReq", "Total client requests", nReq);
   cmd.AddValue("interval", "Seconds between requests", interval);
@@ -24,6 +24,7 @@ int main(int argc, char** argv){
   cmd.AddValue("numContent", "Number of distinct content items (1 = fixed resource)", numContent);
   cmd.AddValue("zipf", "Use Zipf popularity over resources", zipf);
   cmd.AddValue("zipfS", "Zipf exponent s (>0)", zipfS);
+  cmd.AddValue("cacheDelay", "Cache processing delay for hits (ms)", cacheDelay);
   cmd.AddValue("originDelay", "Origin processing delay (ms)", originDelay);
   cmd.Parse(argc, argv);
 
@@ -53,6 +54,7 @@ int main(int argc, char** argv){
   cache->SetOrigin(Address(if12.GetAddress(1)), cacheToOriginPort);
   cache->SetTtl(Seconds(ttl));
   cache->SetCapacity(cacheCap);
+  cache->SetCacheDelay(MilliSeconds(cacheDelay));
   nodes.Get(1)->AddApplication(cache);
   cache->SetStartTime(Seconds(0.2)); cache->SetStopTime(Seconds(100));
 

--- a/model/http-cache-app.cc
+++ b/model/http-cache-app.cc
@@ -21,6 +21,7 @@ void HttpCacheApp::SetListenPort(uint16_t p){ m_listenPort = p; }
 void HttpCacheApp::SetOrigin(Address a, uint16_t p){ m_originAddr = a; m_originPort = p; }
 void HttpCacheApp::SetTtl(Time t){ m_ttl = t; }
 void HttpCacheApp::SetCapacity(uint32_t c){ m_capacity = c; }
+void HttpCacheApp::SetCacheDelay(Time t){ m_cacheDelay = t; }
 
 void HttpCacheApp::StartApplication(){
   m_clientSock = Socket::CreateSocket(GetNode(), UdpSocketFactory::GetTypeId());
@@ -56,7 +57,7 @@ void HttpCacheApp::HandleClientRead(Ptr<Socket> sock){
     if (it != m_map.end() && it->second.expiry > now){
       NS_LOG_INFO("Cache HIT key=" << key);
       Touch(key);
-      ReplyToClient(hdr.GetRequestId(), key, true, from);
+      Simulator::Schedule(m_cacheDelay, &HttpCacheApp::ReplyToClient, this, hdr.GetRequestId(), key, true, from);
     } else {
       NS_LOG_INFO("Cache MISS key=" << key);
       // miss -> forward to origin

--- a/model/http-cache-app.h
+++ b/model/http-cache-app.h
@@ -18,6 +18,7 @@ public:
   void SetOrigin(Address a, uint16_t p);
   void SetTtl(Time t);
   void SetCapacity(uint32_t entries);
+  void SetCacheDelay(Time t);
 
 private:
   struct Entry { std::string value; Time expiry; std::list<std::string>::iterator it; };
@@ -34,6 +35,7 @@ private:
   Address m_originAddr; uint16_t m_originPort = 8081;
   uint16_t m_listenPort = 8080;
   Time m_ttl{Seconds(5)}; uint32_t m_capacity = 64;
+  Time m_cacheDelay{MilliSeconds(1)};
 
   // LRU structures
   std::list<std::string> m_lru;


### PR DESCRIPTION
## :memo: Summary

Fixes #7 - Adds `--cacheDelay` flag to configure cache processing delay for hits, enabling simulation of different cache hardware speeds.

## :bulb: Motivation

Currently cache hits have minimal fixed latency. This feature allows modeling:
- Fast caches (SSD, RAM-based): Low delay
- Slow caches (HDD-based): Higher delay
- Realistic cache processing overhead
- Comparison of hit vs miss latency benefits

## :wrench: Changes Made

### HttpCacheApp
- Added `m_cacheDelay` member variable (default: 1ms)
- Added `SetCacheDelay(Time t)` method
- Modified `HandleClientRead()` to use `Simulator::Schedule()` for delayed cache hit responses

### Scenario
- Added `--cacheDelay` CLI flag (default: 1ms)
- Applied to cache configuration via `cache->SetCacheDelay(MilliSeconds(cacheDelay))`

### Files Modified
- `model/http-cache-app.h` - Added delay parameter and setter
- `model/http-cache-app.cc` - Implemented scheduled delayed response
- `examples/http-cache-scenario.cc` - Added CLI flag

## :white_check_mark: Testing

:heavy_check_mark: **Build:** Successful compilation

:heavy_check_mark: **Help Text:** Flag appears correctly
```bash
--cacheDelay:   Cache processing delay for hits (ms) [1]
```

:heavy_check_mark: **Default (1ms):** Cache hits show ~5ms total latency
```csv
request_id,content,send_s,recv_s,latency_ms,cache_hit
4,/file-3,2.3,2.30501,5,1
```

:heavy_check_mark: **High delay (10ms):** Cache hits show ~14ms total latency
```csv
request_id,content,send_s,recv_s,latency_ms,cache_hit
4,/file-3,2.3,2.31401,14,1
```

:heavy_check_mark: **Misses unchanged:** Origin delay still applies correctly (~15ms)

## :chart_with_upwards_trend: Use Cases

**Example 1: Fast cache (SSD/RAM)**
```bash
./ns3 run http-cache-scenario -- --cacheDelay=1 --originDelay=50
```
Result: Hits ~5ms, Misses ~54ms → Strong cache benefit

**Example 2: Slow cache (HDD)**
```bash
./ns3 run http-cache-scenario -- --cacheDelay=10 --originDelay=100
```
Result: Hits ~14ms, Misses ~104ms → Cache still beneficial but less dramatic

**Example 3: Compare cache types**
```bash
# Test with RAM cache
./ns3 run http-cache-scenario -- --cacheDelay=0.5 --csv=ram_cache.csv

# Test with HDD cache  
./ns3 run http-cache-scenario -- --cacheDelay=8 --csv=hdd_cache.csv
```

## :link: Related Issues

Complements #7 (origin delay) for complete latency modeling

## :mag: Technical Details

Uses same pattern as `HttpOriginApp`:
- `Simulator::Schedule(m_cacheDelay, &HttpCacheApp::ReplyToClient, ...)`
- Schedules response after specified delay
- Non-blocking - simulation continues